### PR TITLE
docker/lighweight first tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fpco/stack-build:lts-16.31
+FROM haskell:8.8.4-buster
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 


### PR DESCRIPTION
Give a try to build image with 
- `haskell:8.8.4-buster` official image (350MB vs 3.5GB) : https://hub.docker.com/_/haskell?tab=tags&page=1&ordering=last_updated
- rest is the same

RESULT 1 : __compressed image 884MB (goal <1GB)__
RESULT 2 : __website CI is OK total < 2min (with caching) and spin up ~30sec (goal for the spin up step <1min )__